### PR TITLE
update to 0.17.1.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:stable AS build
 ARG DEBIAN_FRONTEND=noninteractive
 
 #only to force hub.docker.com image to rebuild
-ENV MONERO_VERSION=0.17.1.1 
+ENV MONERO_VERSION=0.17.1.3
 
 WORKDIR /root
 RUN apt-get -y update && apt-get -y install curl lbzip2 && \


### PR DESCRIPTION
Updated to Monero version [0.17.1.3](https://github.com/monero-project/monero/releases/tag/v0.17.1.3)